### PR TITLE
Add ENT:CallOnServer() and ENT:CallOnClient()

### DIFF
--- a/lua/entities/drgbase_nextbot/misc.lua
+++ b/lua/entities/drgbase_nextbot/misc.lua
@@ -109,6 +109,41 @@ function ENT:RandomizeBodygroups()
 	end
 end
 
+if SERVER then
+	util.AddNetworkString('DrGBaseCallOnRealm')
+
+	function ENT:CallOnClient(funcname, ply, ...)
+		net.Start('DrGBaseCallOnRealm')
+		net.DrG_WriteMessage(self, funcname, ...)
+		
+		if ply then
+			net.Send(ply)
+		else
+			net.Broadcast()
+		end
+	end
+else
+	function ENT:CallOnServer(funcname, ...)
+		net.Start('DrGBaseCallOnRealm')
+		net.DrG_WriteMessage(self, funcname, ...)
+		net.SendToServer()
+	end
+end
+
+net.Receive('DrGBaseCallOnRealm', function(len, ply)
+	local args = net.DrG_ReadMessage()
+	local ent = args[1]
+
+	if IsValid(ent) then
+		local funcname = args[2]
+		local func = ent[funcname]
+
+		if func and isfunction(func) then
+			func(ent, ply or LocalPlayer(), table.DrG_Unpack(args, #args, 3))
+		end
+	end
+end)
+
 -- Hooks --
 
 function ENT:OnAngleChange() end


### PR DESCRIPTION
Functions to call functions on the opposite realm. I think this is very convenient, and you don't need to add more net receivers.

### How it works
`ENT:CallOnClient()` has 2 arguments, and varargs. The first argument is the name of the function you want to call on the client, and the second argument is the player client you want it to be ran on. If the player argument is nil, it will be ran on all clients.

`ENT:CallOnServer()` works the same as CallOnClient, except without the player argument.

These functions will provide the player that send/received the message as well as the varargs to the function you're trying to call on server/client.

**Example**
```
if CLIENT then
	function ENT:ClientTest(ply, ent, str, num)
		print('Player', tostring(ent), 'got attacked by', tostring(self))
		print(str, num)
	end
end

if SERVER then
        function ENT:OnMeleeAttack(ent)
                if ent:IsPlayer() then
		        self:CallOnClient('ClientTest', nil, ent, ent:Name(), ent:Health())
                end
        end
end
```
In this example, when the NextBot attacks a player, it will broadcast `ENT:ClientTest()` to all players.