### PR TITLE
Set weapon position to NextBot center in ENT:PickupWeapon

### DIFF
--- a/lua/entities/drgbase_nextbot/weapons.lua
+++ b/lua/entities/drgbase_nextbot/weapons.lua
@@ -219,6 +219,8 @@ if SERVER then
 	function ENT:PickupWeapon(weapon)
 		if not IsWeapon(weapon) then return false end
 		if self:HasWeapon(weapon:GetClass()) then return false end
+		weapon:SetPos(self:WorldSpaceCenter())
+		weapon:SetNotSolid(true)
 		weapon:SetMoveType(MOVETYPE_NONE)
 		weapon:SetOwner(self)
 		weapon:SetParent(self)
@@ -255,6 +257,7 @@ if SERVER then
 		self:NetMessage("DrGBaseDropWeapon", weapon:GetClass())
 		if active == weapon then self:SwitchWeapon() end
 		weapon:SetNoDraw(false)
+		weapon:SetNotSolid(false)
 		return weapon
 	end
 


### PR DESCRIPTION
Fixes https://github.com/Dragoteryx/drgbase/issues/10

The problem was that the weapon is left at worldspawn and parented, so for example, if you spawned the NextBot in a map like gm_flatgrass, you would almost never be able to hear the gun shots 