### PR TITLE
Stop some files from being included in realms they shouldn't

### DIFF
--- a/lua/autorun/drgbase.lua
+++ b/lua/autorun/drgbase.lua
@@ -71,9 +71,15 @@ function DrGBase.IncludeFile(fileName)
 	local explode = string.Explode("[/\\]", fileName, true)
 	local last = explode[#explode]
 	if string.StartWith(last, "sv_") then
-		if SERVER then return IncludeFile(fileName) end
+		if SERVER then 
+			return IncludeFile(fileName) 
+		end
 	elseif string.StartWith(last, "cl_") then
-		if CLIENT then return IncludeFile(fileName) end
+		if SERVER then
+			AddCSLuaFile(fileName)
+		else
+			return IncludeFile(fileName) 
+		end
 	else
 		AddCSLuaFile(fileName)
 		return IncludeFile(fileName)

--- a/lua/drgbase/cl_dpanels.lua
+++ b/lua/drgbase/cl_dpanels.lua
@@ -1,5 +1,3 @@
-if SERVER then return end
-
 function DrGBase.DListView(columns, options)
 	if not istable(options) then options = {} end
 	local dlist = vgui.Create("DListView")

--- a/lua/drgbase/cl_spawnmenu.lua
+++ b/lua/drgbase/cl_spawnmenu.lua
@@ -1,5 +1,3 @@
-if SERVER then return end
-
 function DrGBase.GetIcon(name)
   return list.Get("DrGBaseIcons")[name]
 end

--- a/lua/drgbase/modules/cl_render.lua
+++ b/lua/drgbase/modules/cl_render.lua
@@ -1,5 +1,3 @@
-if SERVER then return end
-
 function render.DrG_DrawSprite(sprite, pos, size, options)
 	options = options or {}
 	size = isnumber(size) and math.Clamp(size, 0, math.huge) or 100

--- a/lua/drgbase/modules/sv_navmesh.lua
+++ b/lua/drgbase/modules/sv_navmesh.lua
@@ -1,5 +1,3 @@
-if CLIENT then return end
-
 local NAVAREAS_CENTERS = {}
 function navmesh.DrG_GetAreaFromCenter(pos)
 	return NAVAREAS_CENTERS[tostring(pos)]

--- a/lua/drgbase/resources.lua
+++ b/lua/drgbase/resources.lua
@@ -1,3 +1,0 @@
-if CLIENT then return end
-
-resource.AddFile("materials/drgbase/icon16.png")

--- a/lua/drgbase/sv_resources.lua
+++ b/lua/drgbase/sv_resources.lua
@@ -1,0 +1,1 @@
+resource.AddFile("materials/drgbase/icon16.png")

--- a/lua/entities/drgbase_nextbot/shared.lua
+++ b/lua/entities/drgbase_nextbot/shared.lua
@@ -15,6 +15,7 @@ ENT.RagdollOnDeath = true
 
 -- Stats --
 DrGBase.IncludeFile("status.lua")
+
 ENT.SpawnHealth = 100
 ENT.HealthRegen = 0
 ENT.MinPhysDamage = 10
@@ -23,6 +24,7 @@ ENT.MinFallDamage = 10
 -- AI --
 DrGBase.IncludeFile("ai.lua")
 DrGBase.IncludeFile("patrol.lua")
+
 ENT.BehaviourType = AI_BEHAV_BASE
 ENT.Omniscient = false
 ENT.SpotDuration = 30
@@ -35,6 +37,7 @@ ENT.WatchAfraidOfRange = 750
 
 -- Relationships --
 DrGBase.IncludeFile("relationships.lua")
+
 ENT.DefaultRelationship = D_NU
 ENT.Factions = {}
 ENT.Frightening = false
@@ -45,6 +48,7 @@ ENT.NeutralDamageTolerance = 0.33
 -- Detection --
 DrGBase.IncludeFile("awareness.lua")
 DrGBase.IncludeFile("detection.lua")
+
 ENT.EyeBone = ""
 ENT.EyeOffset = Vector(0, 0, 0)
 ENT.EyeAngle = Angle(0, 0, 0)
@@ -55,8 +59,11 @@ ENT.MaxLuminosity = 1
 ENT.HearingCoefficient = 1
 
 -- Locomotion --
-DrGBase.IncludeFile("locomotion.lua")
-DrGBase.IncludeFile("path.lua")
+if SERVER then
+	DrGBase.IncludeFile("sv_locomotion.lua")
+	DrGBase.IncludeFile("sv_path.lua")
+end
+
 ENT.Acceleration = 1000
 ENT.Deceleration = 1000
 ENT.JumpHeight = 50
@@ -66,6 +73,7 @@ ENT.DeathDropHeight = 200
 
 -- Movements --
 DrGBase.IncludeFile("movements.lua")
+
 ENT.UseWalkframes = false
 ENT.WalkSpeed = 100
 ENT.RunSpeed = 200
@@ -93,6 +101,7 @@ ENT.ClimbOffset = Vector(0, 0, 0)
 
 -- Animations --
 DrGBase.IncludeFile("animations.lua")
+
 ENT.WalkAnimation = ACT_WALK
 ENT.WalkAnimRate = 1
 ENT.RunAnimation = ACT_RUN
@@ -115,6 +124,7 @@ ENT.Footsteps = {}
 
 -- Weapons --
 DrGBase.IncludeFile("weapons.lua")
+
 ENT.UseWeapons = false
 ENT.Weapons = {}
 ENT.DropWeaponOnDeath = false
@@ -122,6 +132,7 @@ ENT.AcceptPlayerWeapons = true
 
 -- Possession --
 DrGBase.IncludeFile("possession.lua")
+
 ENT.PossessionEnabled = false
 ENT.PossessionPrompt = true
 ENT.PossessionCrosshair = false

--- a/lua/entities/drgbase_nextbot/sv_locomotion.lua
+++ b/lua/entities/drgbase_nextbot/sv_locomotion.lua
@@ -1,5 +1,3 @@
-if CLIENT then return end
-
 -- Handlers --
 
 function ENT:_InitLocomotion()

--- a/lua/entities/drgbase_nextbot/sv_path.lua
+++ b/lua/entities/drgbase_nextbot/sv_path.lua
@@ -1,5 +1,3 @@
-if CLIENT then return end
-
 -- Handlers --
 
 function ENT:_InitPath()

--- a/lua/entities/drgbase_nextbot/sv_path.lua
+++ b/lua/entities/drgbase_nextbot/sv_path.lua
@@ -69,7 +69,6 @@ function ENT:BlacklistedNavAreas()
 	return areas
 end
 
-local ENABLE_JUMPING = false
 function ENT:GetPathGenerator()
 	return function(area, fromArea, ladder, elevator, length)
 		if not IsValid(fromArea) then return 0 end
@@ -82,48 +81,51 @@ function ENT:GetPathGenerator()
 		elseif length > 0 then dist = length
 		else dist = fromArea:GetCenter():Distance(area:GetCenter()) end
 		local cost = fromArea:GetCostSoFar() + dist
-		local height = fromArea:ComputeAdjacentConnectionHeightChange(area)
-		if height > 0 then
-			if IsValid(ladder) then
+		if IsValid(ladder) then
+			local height = ladder:GetTop().z - ladder:GetBottom().z
+			if ladder:GetBottomArea() == fromArea then
 				if not self.ClimbLaddersUp then return -1 end
 				if height < self.ClimbLaddersUpMinHeight then return -1 end
 				if height > self.ClimbLaddersUpMaxHeight then return -1 end
 				local res = self:OnComputePathLadderUp(fromArea, area, ladder)
-				if res >= 0 then cost = cost + dist*res else return -1 end
-			elseif height < self.loco:GetStepHeight() then
-				local res = self:OnComputePathStep(fromArea, area, height)
-				if res >= 0 then cost = cost + dist*res else return -1 end
-			elseif ENABLE_JUMPING and height < self.loco:GetJumpHeight() then
-				local res = self:OnComputePathJump(fromArea, area, height)
-				if res >= 0 then cost = cost + dist*res else return -1 end
-			elseif self.ClimbLedges then
-				if height < self.ClimbLedgesMinHeight then return -1 end
-				if height > self.ClimbLedgesMaxHeight then return -1 end
-				local res = self:OnComputePathLedge(fromArea, area, height)
-				if res >= 0 then cost = cost + dist*res else return -1 end
-			else return -1 end
-		elseif height < 0 then
-			local drop = -height
-			if IsValid(ladder) then
+				if res >= 0 then cost = cost + dist * res else return -1 end
+			else
+				local drop = -height
 				if not self.ClimbLaddersDown then return -1 end
 				if drop < self.ClimbLaddersDownMinHeight then return -1 end
 				if drop > self.ClimbLaddersDownMaxHeight then return -1 end
 				local res = self:OnComputePathLadderDown(fromArea, area, ladder)
-				if res >= 0 then cost = cost + dist*res else return -1 end
-			elseif drop < self.loco:GetDeathDropHeight() then
-				local res = self:OnComputePathDrop(fromArea, area, drop)
-				if res >= 0 then cost = cost + dist*res else return -1 end
-			else return -1 end
+				if res >= 0 then cost = cost + dist * res else return -1 end
+			end
 		else
-			local res = self:OnComputePathFlat(fromArea, area)
-			if res >= 0 then cost = cost + dist*res else return -1 end
+			local height = fromArea:ComputeAdjacentConnectionHeightChange(area)
+			if height > 0 then
+				if height < self.loco:GetStepHeight() then
+					local res = self:OnComputePathStep(fromArea, area, height)
+					if res >= 0 then cost = cost + dist * res else return -1 end
+				elseif self.ClimbLedges then
+					if height < self.ClimbLedgesMinHeight then return -1 end
+					if height > self.ClimbLedgesMaxHeight then return -1 end
+					local res = self:OnComputePathLedge(fromArea, area, height)
+					if res >= 0 then cost = cost + dist * res else return -1 end
+				else return -1 end
+			elseif height < 0 then
+				local drop = -height
+				if drop < self.loco:GetDeathDropHeight() then
+					local res = self:OnComputePathDrop(fromArea, area, drop)
+					if res >= 0 then cost = cost + dist * res else return -1 end
+				else return -1 end
+			else
+				local res = self:OnComputePathFlat(fromArea, area)
+				if res >= 0 then cost = cost + dist * res else return -1 end
+			end
+			if area:IsUnderwater() then
+				local res = self:OnComputePathUnderwater(fromArea, area)
+				if res >= 0 then cost = cost + dist * res else return -1 end
+			end
+			local res = self:OnComputePath(fromArea, area)
+			if res >= 0 then return cost + dist * res else return -1 end
 		end
-		if area:IsUnderwater() then
-			local res = self:OnComputePathUnderwater(fromArea, area)
-			if res >= 0 then cost = cost + dist*res else return -1 end
-		end
-		local res = self:OnComputePath(fromArea, area)
-		if res >= 0 then return cost + dist*res else return -1 end
 	end
 end
 


### PR DESCRIPTION
Some files have `if CLIENT then return end` or `if SERVER then return end` when you can just not include them on those realms. It's a small optimization, and stops server only files from being sent to clients (there is a limit to how many Lua files that can be sent to clients in multiplayer)