### PR TITLE
Apply VJ_ID_Undead helper tag (Extra compatibility)

### DIFF
--- a/lua/entities/npc_drg_zombie.lua
+++ b/lua/entities/npc_drg_zombie.lua
@@ -6,6 +6,7 @@ ENT.PrintName = "Zombie"
 ENT.Category = "DrGBase"
 ENT.Models = {"models/Zombie/Classic.mdl"}
 ENT.BloodColor = BLOOD_COLOR_GREEN
+ENT.VJ_ID_Undead = true
 
 -- Sounds --
 ENT.OnDamageSounds = {"Zombie.Pain"}


### PR DESCRIPTION
Helps VJ NPCs recognize the zombie as an undead being